### PR TITLE
Domain DataObject for SAP

### DIFF
--- a/esql-checks/src/main/java/com/exxeta/iss/sonar/esql/check/UnknownMessageDomainCheck.java
+++ b/esql-checks/src/main/java/com/exxeta/iss/sonar/esql/check/UnknownMessageDomainCheck.java
@@ -31,7 +31,7 @@ public class UnknownMessageDomainCheck extends DoubleDispatchVisitorCheck {
 
 	private static List<String> rootElements = Collections.unmodifiableList(Lists.newArrayList("InputRoot", "OutputRoot", "Root"));
 	private static List<String> domains = Collections.unmodifiableList(Lists.newArrayList("DFDL","MRM", "XML", "XMLNS", "XMLNSC", "JMS", "IDOC", "MIME", "BLOB", "JSON", "SOAP", 
-			"Properties", "HTTPRequestHeader", "HTTPResponseHeader", "HTTPInputHeader", "HTTPReplyHeader", "MQMD", "MQRFH2", "EmailOutputHeader", "EmailInputHeader", "Collection", "*", "MQPCF"));
+			"Properties", "HTTPRequestHeader", "HTTPResponseHeader", "HTTPInputHeader", "HTTPReplyHeader", "MQMD", "MQRFH2", "EmailOutputHeader", "EmailInputHeader", "Collection", "*", "MQPCF", "DataObject"));
 	
 	
 	@Override


### PR DESCRIPTION
Hi!

The rule "The message domain is undefined" is not recognizing the domain DataObject, that i'm using in a project with SAP integration. 
So im having this issue in sonar.

Thanks!