### PR TITLE
Bug fixed for SubElementNameCheck

### DIFF
--- a/esql-checks/src/main/java/com/exxeta/iss/sonar/esql/check/SubElementNameCheck.java
+++ b/esql-checks/src/main/java/com/exxeta/iss/sonar/esql/check/SubElementNameCheck.java
@@ -45,15 +45,17 @@ public class SubElementNameCheck extends DoubleDispatchVisitorCheck {
 			FieldReferenceTree fieldRef = (FieldReferenceTree) tree.variableReference();
 			if ("Environment".equalsIgnoreCase(fieldRef.pathElement().name().name().name())) {
 				int subElementsSize = fieldRef.pathElements().size();
-				for (int i = 0; i < subElementsSize - 1; i++) {
-					String subElement = fieldRef.pathElements().get(i).name().name().name();
-					if (!subElement.matches(UPPERCASE_FORMAT)) {
+				if (subElementsSize > 0) {
+					for (int i = 0; i < subElementsSize - 1; i++) {
+						String subElement = fieldRef.pathElements().get(i).name().name().name();
+						if (!subElement.matches(UPPERCASE_FORMAT)) {
+							addIssue(tree, MESSAGE);
+						}
+					}
+					String lastElement = fieldRef.pathElements().get(subElementsSize - 1).name().name().name();
+					if (!lastElement.matches(LOWERCASE_FORMAT)) {
 						addIssue(tree, MESSAGE);
 					}
-				}
-				String lastElement = fieldRef.pathElements().get(subElementsSize - 1).name().name().name();
-				if (!lastElement.matches(LOWERCASE_FORMAT)) {
-					addIssue(tree, MESSAGE);
 				}
 
 			}

--- a/esql-checks/src/test/java/com/exxeta/iss/sonar/esql/check/SubElementNameCheckTest.java
+++ b/esql-checks/src/test/java/com/exxeta/iss/sonar/esql/check/SubElementNameCheckTest.java
@@ -35,7 +35,8 @@ public class SubElementNameCheckTest {
 	public void test() {
 		EsqlCheck check = new SubElementNameCheck();
 		EsqlCheckVerifier.issues(check, new File("src/test/resources/SubElementName.esql"))
-		.next().atLine(5).withMessage("sub-elements should be in UpperCamel-case and elements containing simple value should be in lowercase.")
-		.next().atLine(6).withMessage("sub-elements should be in UpperCamel-case and elements containing simple value should be in lowercase.").noMore();
+				.next().atLine(5).withMessage("sub-elements should be in UpperCamel-case and elements containing simple value should be in lowercase.")
+				.next().atLine(6).withMessage("sub-elements should be in UpperCamel-case and elements containing simple value should be in lowercase.")
+				.next().atLine(9).withMessage("sub-elements should be in UpperCamel-case and elements containing simple value should be in lowercase.").noMore();
 	}
 }

--- a/esql-checks/src/test/resources/SubElementName.esql
+++ b/esql-checks/src/test/resources/SubElementName.esql
@@ -2,11 +2,18 @@ CREATE COMPUTE MODULE Module1
 
 	CREATE FUNCTION Main() RETURNS BOOLEAN
 	BEGIN
-	      SET Environment.Variables.startVar.xyz ='ABC';
-	      SET Environment.Variables.Flag ='ABC';
-	      SET Environment.xyz ='true';
-	      SET Environment.Fault.faultcode ='soapenv:Client';
-	    
+        SET Environment.Variables.startVar.xyz ='ABC';
+        SET Environment.Variables.Flag ='ABC';
+        SET Environment.xyz ='true';
+        SET Environment.Fault.faultcode ='soapenv:Client';
+        SET Environment.Variables.Mch.Sync.CORRELID
+                =
+                InputLocalEnvironment.
+                WrittenDestination.
+                MQ.
+                DestinationData.
+                msgId;
+		
 		
 	END;
 

--- a/esql-checks/src/test/resources/SubElementName.esql
+++ b/esql-checks/src/test/resources/SubElementName.esql
@@ -2,17 +2,17 @@ CREATE COMPUTE MODULE Module1
 
 	CREATE FUNCTION Main() RETURNS BOOLEAN
 	BEGIN
-        SET Environment.Variables.startVar.xyz ='ABC';
-        SET Environment.Variables.Flag ='ABC';
-        SET Environment.xyz ='true';
-        SET Environment.Fault.faultcode ='soapenv:Client';
-        SET Environment.Variables.Mch.Sync.CORRELID
-                =
-                InputLocalEnvironment.
-                WrittenDestination.
-                MQ.
-                DestinationData.
-                msgId;
+		SET Environment.Variables.startVar.xyz ='ABC';
+		SET Environment.Variables.Flag ='ABC';
+		SET Environment.xyz ='true';
+		SET Environment.Fault.faultcode ='soapenv:Client';
+		SET Environment.Variables.Mch.Sync.CORRELID
+				=
+				InputLocalEnvironment.
+				WrittenDestination.
+				MQ.
+				DestinationData.
+				msgId;
 		
 		
 	END;


### PR DESCRIPTION
Test SubElementNameCheck crashes with error "java.lang.StringIndexOutOfBoundsException: String index out of range: -19"

The code is:
>         SET Environment.Variables.Mch.Sync.CORRELID
>                 =
>                 InputLocalEnvironment.
>                 WrittenDestination.
>                 MQ.
>                 DestinationData.
>                 msgId;